### PR TITLE
Add missing Foundation imports

### DIFF
--- a/Sources/QueuesFluentDriver/PopQueries/MySQLPopQuery.swift
+++ b/Sources/QueuesFluentDriver/PopQueries/MySQLPopQuery.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SQLKit
 import Fluent
 

--- a/Sources/QueuesFluentDriver/PopQueries/SqlitePopQuery.swift
+++ b/Sources/QueuesFluentDriver/PopQueries/SqlitePopQuery.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SQLKit
 import Fluent
 


### PR DESCRIPTION
`Date` is a `Foundation` type, so these imports are required for the code to compile properly.