### PR TITLE
Remove code to shutdown EventLoopGroup in FluentQueuesDriver

### DIFF
--- a/Sources/QueuesFluentDriver/FluentQueuesDriver.swift
+++ b/Sources/QueuesFluentDriver/FluentQueuesDriver.swift
@@ -49,7 +49,5 @@ extension FluentQueuesDriver: QueuesDriver {
     }
     
     public func shutdown() {
-        // What are we supposed to do here?
-        try? self.eventLoopGroup.syncShutdownGracefully()
     }
 }


### PR DESCRIPTION
This will fix error message:

ERROR: Cannot schedule tasks on an EventLoop that has already shut down. This will be upgraded to a forced crash in future SwiftNIO versions.

when using Ctrl+C to shut down application. EventLoopGroup here is not owned by FluentQueuesDriver and used by other objects during shutdown procedure

Fixes #6